### PR TITLE
Fix: Task Configuration Avoidance

### DIFF
--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
@@ -35,12 +35,13 @@ class HuaweiPublishPlugin : Plugin<Project> {
     private fun createTask(project: Project, variant: ApplicationVariant) {
         val variantName = variant.name.capitalize()
         val publishTaskName = "${HuaweiPublishTask.TASK_NAME}$variantName"
-        val publishTask = project.tasks.register<HuaweiPublishTask>(publishTaskName, variant)
-
-        project.tasks.whenTaskAdded {
-            if (this.name == "assemble$variantName" || this.name == "bundle$variantName") {
-                publishTask.get().mustRunAfter(this)
-            }
+        project.tasks.register<HuaweiPublishTask>(publishTaskName, variant).configure {
+            setMustRunAfter(
+                setOf(
+                    project.tasks.named("assemble$variantName"),
+                    project.tasks.named("bundle$variantName"),
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
### Problem
To establish a soft relationship between tasks, the plugin uses the [whenTaskAdded](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/TaskCollection.html#whenTaskAdded-org.gradle.api.Action-) method. This breaks the [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html).
See scan for task `./gradlew :app:help`:
![plugin-task-configuration-avoidance-problem](https://user-images.githubusercontent.com/12980966/234941397-c4bf9421-e564-4dfe-905e-be8a68636f99.png)

### Quick fix
Replace `whenTaskAdded` with `configureEach`. But we are still losing "laziness" for the `publishHuaweiAppGallery` task in this line:
```kotlin
publishTask.get().mustRunAfter(this)
```
### Solution
We can be sure that the project contains `assemble` and `bundle` tasks, because the plugin is only used together with `com.android.application`:
```kotlin
project.plugins.withType<AppPlugin> {
    configureHuaweiPublish(project)
}
```

Therefore, we can establish the relationship between the tasks as follows:
```kotlin
project.tasks.register<HuaweiPublishTask>(publishTaskName, variant).configure {
    setMustRunAfter(
        setOf(
            project.tasks.named("assemble$variantName"),
            project.tasks.named("bundle$variantName"),
        )
    )
}
```

### Need testing!